### PR TITLE
[deploy] docker-compose: build back-end image ...

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,10 @@ services:
     ports:
       - ${REDIS_PORT}:6379
   back-end:
-    image: gneiss-back:latest
+    build:
+      context: .
+      dockerfile: back-end/Dockerfile
+
     environment:
       MYSQL_DATABASE: ${MYSQL_DATABASE}
       MYSQL_USER: ${MYSQL_USER}


### PR DESCRIPTION
Using a tagged image only works when it is published on the docker server (e.g. redis:latest). For your custom images, it's better to build them from scratch inside the docker-compose file. This makes deployment more portable and you don't have to worry about publishing and maintaining your custom image.